### PR TITLE
fix: run pre-push checks on all branches, not just main/master

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -54,26 +54,10 @@ https://* | http://*)
   ;;
 esac
 
-# Only run checks when pushing to main (or master)
-protected_branches=("refs/heads/main" "refs/heads/master")
-
-run_checks=false
+# Drain stdin (required by git pre-push hook protocol)
 while read -r local_ref local_sha remote_ref remote_sha; do
-  for branch in "${protected_branches[@]}"; do
-    if [[ "$remote_ref" == "$branch" ]]; then
-      run_checks=true
-      break 2 # break out of both loops once we find a match
-    fi
-  done
+  : # checks run on every branch — no branch filtering
 done
-
-if [[ "$run_checks" != "true" ]]; then
-  # Optional: uncomment if you want feedback when skipping
-  info "Not pushing to main/master → skipping Rust quality gate"
-  exit 0
-fi
-
-# If we reach here → proceed with Rust detection and checks
 
 # Detect Rust project by policy files
 required_files=(


### PR DESCRIPTION
Removes the `protected_branches` filter from `.git-hooks/pre-push` that caused the full check suite to only run when pushing to main/master. All pushes now run the full quality gate (cargo fmt, clippy, tests, cargo deny) regardless of branch.

Closes #1