### PR TITLE
[#15] Add .gitignore environment patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ docker-container-*
 *.swo
 *.bak
 *.tmp
+
+# -----------------------------
+# Configuration files
+# -----------------------------
+configuration/local.yaml
+configuration/production.yaml


### PR DESCRIPTION
Add environment and configuration file patterns to .gitignore

- Add configuration/local.yaml and configuration/production.yaml patterns
- Closes #15

**Pre-push checks:**
- ✅ cargo +nightly fmt -- --check
- ✅ cargo +nightly clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks
- ✅ cargo +nightly miri test --lib -- --nocapture
- ✅ cargo +nightly deny check
- ⚠️ cargo +nightly llvm-cov --lib --fail-under-lines 50 (no tests in template)