### PR TITLE
fix: guard stdin drain with TTY check in smoke-test.sh

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -50,9 +50,13 @@ https://* | http://*)
 esac
 
 # Drain stdin (required by git pre-push hook protocol)
-while read -r local_ref local_sha remote_ref remote_sha; do
-  : # checks run on every branch — no branch filtering
-done
+# Guard: only drain when stdin is a pipe (not a terminal), so the script
+# doesn't hang when a developer runs it directly from the command line.
+if [[ ! -t 0 ]]; then
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    : # checks run on every branch — no branch filtering
+  done
+fi
 
 # Detect Rust project by policy files
 required_files=(


### PR DESCRIPTION
## What

Cherry-picks the orphaned commit `fa6592a` from `chore/sync-scripts-dir` that was pushed after PR #21 merged.

### Change
- Guard the stdin drain in `smoke-test.sh` with `[[ ! -t 0 ]]` so the script doesn't hang when invoked directly from a terminal (outside CI).

### Already in main (via PR #21 merge)
- `SKIP_TESTS=1` on the smoke-test step in `cooked-crab.yaml` ✅
- `SKIP_TESTS` (plural) check in `smoke-test.sh` ✅  
- `--no-pager` in `ci_env.toml` default flags ✅

Only this TTY-guard fix was orphaned.

Closes the gap from the post-merge commits on `chore/sync-scripts-dir`.