### PR TITLE
fix: use runs-on: mae-runner (ARC scale sets route by name, not label array)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   config:
     name: 📋 Read Config
-    runs-on: [self-hosted, mae-runner]
+    runs-on: mae-runner
     outputs:
       neo4j_user: ${{ steps.read.outputs.neo4j_user }}
       neo4j_password: ${{ steps.read.outputs.neo4j_password }}
@@ -41,7 +41,7 @@ jobs:
 
   integrity:
     name: 🦀 Ferris Says No Bugs
-    runs-on: [self-hosted, mae-runner]
+    runs-on: mae-runner
     needs: config
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
 
   integration:
     name: ⚙️ Integration Gauntlet
-    runs-on: [self-hosted, mae-runner]
+    runs-on: mae-runner
     needs: [integrity, config]
     env:
       NEO4J_USER: ${{ needs.config.outputs.neo4j_user }}


### PR DESCRIPTION
ARC runner scale sets route jobs by runner name only — `[self-hosted, mae-runner]` won't match; it must be just `mae-runner`.\n\nChanged all 3 jobs in ci.yml from `runs-on: [self-hosted, mae-runner]` to `runs-on: mae-runner`.