### PR TITLE
fix: yq install path for non-root ARC runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
 
       - name: Install yq
         run: |
-          command -v yq >/dev/null 2>&1 || \
-            (curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-              -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq)
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o "$HOME/.local/bin/yq" && chmod +x "$HOME/.local/bin/yq"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Read config
         id: read
@@ -108,9 +109,10 @@ jobs:
 
       - name: Install yq
         run: |
-          command -v yq >/dev/null 2>&1 || \
-            (curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-              -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq)
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o "$HOME/.local/bin/yq" && chmod +x "$HOME/.local/bin/yq"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Load database config from test.yaml
         run: |


### PR DESCRIPTION
ARC runners run as non-root and cannot write to /usr/local/bin. Install yq to $HOME/.local/bin and add to GITHUB_PATH instead.