### PR TITLE
fix: install build-essential on ARC runners — cc linker missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+
       - name: Install yq
         run: |
-          command -v yq >/dev/null 2>&1 || \
-            (curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-              -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq)
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o "$HOME/.local/bin/yq" && chmod +x "$HOME/.local/bin/yq"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Read config
         id: read
@@ -45,6 +51,11 @@ jobs:
     needs: config
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y build-essential pkg-config libssl-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -98,6 +109,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -108,9 +124,10 @@ jobs:
 
       - name: Install yq
         run: |
-          command -v yq >/dev/null 2>&1 || \
-            (curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-              -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq)
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o "$HOME/.local/bin/yq" && chmod +x "$HOME/.local/bin/yq"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Load database config from test.yaml
         run: |


### PR DESCRIPTION
ARC runner container image does not include gcc/cc. Installing build-essential, pkg-config, and libssl-dev before any Rust compilation steps.