### PR TITLE
fix: full CI deps sweep + rename config job to 🕵️ Crab Intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
       neo4j_password: ${{ steps.read.outputs.neo4j_password }}
       rabbitmq_user: ${{ steps.read.outputs.rabbitmq_user }}
       rabbitmq_password: ${{ steps.read.outputs.rabbitmq_password }}
+      db_superuser: ${{ steps.read.outputs.db_superuser }}
+      db_superuser_pwd: ${{ steps.read.outputs.db_superuser_pwd }}
+      db_name: ${{ steps.read.outputs.db_name }}
+      db_migrator_user: ${{ steps.read.outputs.db_migrator_user }}
+      db_migrator_pwd: ${{ steps.read.outputs.db_migrator_pwd }}
+      db_app_user: ${{ steps.read.outputs.db_app_user }}
+      db_app_user_pwd: ${{ steps.read.outputs.db_app_user_pwd }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,6 +54,13 @@ jobs:
           echo "neo4j_password=$(echo "$CONFIG" | yq '.graphdb.password')" >> $GITHUB_OUTPUT
           echo "rabbitmq_user=$(echo "$CONFIG" | yq '.messagebroker.username')" >> $GITHUB_OUTPUT
           echo "rabbitmq_password=$(echo "$CONFIG" | yq '.messagebroker.password')" >> $GITHUB_OUTPUT
+          echo "db_superuser=$(echo "$CONFIG" | yq '.database_admin.superuser')" >> $GITHUB_OUTPUT
+          echo "db_superuser_pwd=$(echo "$CONFIG" | yq '.database_admin.superuser_password')" >> $GITHUB_OUTPUT
+          echo "db_name=$(echo "$CONFIG" | yq '.database_admin.db_name // .database.db_name')" >> $GITHUB_OUTPUT
+          echo "db_migrator_user=$(echo "$CONFIG" | yq '.database_admin.migrator_user')" >> $GITHUB_OUTPUT
+          echo "db_migrator_pwd=$(echo "$CONFIG" | yq '.database_admin.migrator_password')" >> $GITHUB_OUTPUT
+          echo "db_app_user=$(echo "$CONFIG" | yq '.database_admin.app_user')" >> $GITHUB_OUTPUT
+          echo "db_app_user_pwd=$(echo "$CONFIG" | yq '.database_admin.app_user_password')" >> $GITHUB_OUTPUT
 
   integrity:
     name: 🦀 Ferris Says No Bugs
@@ -87,6 +101,13 @@ jobs:
       NEO4J_PASSWORD: ${{ needs.config.outputs.neo4j_password }}
       RABBITMQ_USER: ${{ needs.config.outputs.rabbitmq_user }}
       RABBITMQ_PASSWORD: ${{ needs.config.outputs.rabbitmq_password }}
+      POSTGRES_SUPERUSER: ${{ needs.config.outputs.db_superuser }}
+      POSTGRES_SUPERUSER_PWD: ${{ needs.config.outputs.db_superuser_pwd }}
+      APP_DB_NAME: ${{ needs.config.outputs.db_name }}
+      MIGRATOR_USER: ${{ needs.config.outputs.db_migrator_user }}
+      MIGRATOR_PWD: ${{ needs.config.outputs.db_migrator_pwd }}
+      APP_USER: ${{ needs.config.outputs.db_app_user }}
+      APP_USER_PWD: ${{ needs.config.outputs.db_app_user_pwd }}
     services:
       postgres:
         image: ghcr.io/mae-technologies/postgres-mae:latest


### PR DESCRIPTION
Pre-installs all required tools at the top of each job (yq, trufflehog, cargo-deny, build-essential, pkg-config, libssl-dev). Removes scattered install steps added in previous PRs. Renames "Read Config" → "🕵️ Crab Intel".