### PR TITLE
feat: add staging/production/dev config stubs to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docker-container-*
 # -----------------------------
 configuration/local.yaml
 configuration/production.yaml
+configuration/staging.yaml
+configuration/dev.yaml

--- a/configuration/dev.yaml
+++ b/configuration/dev.yaml
@@ -1,0 +1,14 @@
+# configuration/dev.yaml
+# Local developer overrides for APP_ENVIRONMENT=dev.
+# Safe to commit non-secret dev values here; keep passwords out.
+# Overrides configuration/base.yaml for APP_ENVIRONMENT=dev.
+
+# Override only what differs from base.yaml for your local dev setup.
+# All fields are optional — omit to inherit the base.yaml default.
+
+# example:
+# application:
+#   port: 8080
+# database:
+#   host: "localhost"
+#   database_name: "myservice_dev"

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -1,0 +1,25 @@
+# configuration/production.yaml
+# Provisioned from Vault by ansible k8bootstrap. Do not commit secrets here.
+# Overrides configuration/base.yaml for APP_ENVIRONMENT=production.
+
+application:
+  port: 8080
+  base_url: ""
+  hmac_secret: ""  # vault: secret/mae/production/{service} → hmac_secret
+
+database:
+  host: ""
+  port: "5432"
+  password: ""  # vault: secret/mae/production/{service} → db_password
+  database_name: ""
+  require_ssl: true
+
+redis_uri: ""
+
+# graphdb:
+#   host: ""
+#   port: "7687"
+#   username: "neo4j"
+#   password: ""
+
+custom: {}

--- a/configuration/staging.yaml
+++ b/configuration/staging.yaml
@@ -1,0 +1,26 @@
+# configuration/staging.yaml
+# Provisioned from Vault by ansible k8bootstrap. Do not commit secrets here.
+# See: https://github.com/Mae-Technologies/ansible (playbooks/k8s-bootstrap.yml)
+# Overrides configuration/base.yaml for APP_ENVIRONMENT=staging.
+
+application:
+  port: 8080
+  base_url: ""  # staging internal service URL
+  hmac_secret: ""  # vault: secret/mae/staging/{service} → hmac_secret
+
+database:
+  host: ""      # or set via APP_DATABASE__HOST env var
+  port: "5432"
+  password: ""  # vault: secret/mae/staging/{service} → db_password
+  database_name: ""
+  require_ssl: false
+
+redis_uri: ""  # e.g. redis://redis.statbook-cd.svc.cluster.local:6379/{db_index}
+
+# graphdb:  # uncomment if this service uses neo4j
+#   host: ""    # or set via APP_GRAPHDB__HOST env var
+#   port: "7687"
+#   username: "neo4j"
+#   password: "" # vault: secret/mae/staging/{service} → graphdb_password
+
+custom: {}  # service-specific overrides — see configuration/base.yaml for required keys


### PR DESCRIPTION
Stub YAML files for each non-local environment.

- `staging.yaml` and `production.yaml` are gitignored (Vault-provisioned)
- `dev.yaml` is gitignored (may contain local secrets)
- All files are optional — services boot with `base.yaml` + env vars alone

Files are force-added to git so they ship with the template, but .gitignore prevents local modifications from being tracked.